### PR TITLE
Make ppx_sexp_conv compatible with ppxlib.0.18.0

### DIFF
--- a/expander/sexp_grammar_lifter.ml
+++ b/expander/sexp_grammar_lifter.ml
@@ -28,7 +28,7 @@ type atom      = Atom.t
 type var_name  = Sexp.Private.Raw_grammar.var_name
 type type_name = Sexp.Private.Raw_grammar.type_name
 
-let lift_string ~loc s = pexp_constant ~loc (Pconst_string (s, None))
+let lift_string ~loc s = pexp_constant ~loc (Pconst_string (s, loc, None))
 let lift_var_name      = lift_string
 let lift_type_name     = lift_string
 

--- a/ppx_sexp_conv.opam
+++ b/ppx_sexp_conv.opam
@@ -15,7 +15,7 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "sexplib0" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.11.0"}
+  "ppxlib"   {>= "0.18.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "


### PR DESCRIPTION
ppxlib.0.18.0 upgrades to the 4.11 AST which results in a change in string constants representation. This PR makes ppx_sexp_conv compatible with the latest ppxlib.

You might want for the actual release of ppxlib.0.18.0 before merging this!