### PR TITLE
Achieve compatibility with ppxlib 0.22.0

### DIFF
--- a/expander/str_generate_sexp_grammar.ml
+++ b/expander/str_generate_sexp_grammar.ml
@@ -604,7 +604,7 @@ let singleton ~loc ~path core_type : t =
     let type_variables, core_type =
       collect_type_variables_of_polymorphic_grammar core_type
     in
-    ( List.map type_variables ~f:(fun var_name -> ptyp_var ~loc var_name, Invariant)
+    ( List.map type_variables ~f:(fun var_name -> ptyp_var ~loc var_name, (NoVariance, NoInjectivity))
     , core_type )
   in
   let td =

--- a/ppx_sexp_conv.opam
+++ b/ppx_sexp_conv.opam
@@ -15,7 +15,7 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "sexplib0" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.18.0"}
+  "ppxlib"   {>= "0.22.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "


### PR DESCRIPTION
In ppxlib 0.22.0, the AST gets bumped to ocaml 4.12. This commit adapts to the compiler changes from 4.11 to 4.12: mainly, the introduction of injectivity to type declarations.

It would be good to merge this PR when ppxlib 0.22.0 gets released, which will be soon.

cc @NathanReb