### PR TITLE
Ppxlib.0.26.0 compatibility

### DIFF
--- a/expander/expand_sexp_of.ml
+++ b/expander/expand_sexp_of.ml
@@ -727,7 +727,7 @@ module Str_generate_sexp_of = struct
     let loc = ec.ptyexn_loc in
     let expr =
       match ec.ptyexn_constructor with
-      | { pext_name = cnstr; pext_kind = Pext_decl ([], extension_constructor_kind, None); _ }
+      | { pext_name = cnstr; pext_kind = Pext_decl (_, extension_constructor_kind, None); _ }
         ->
         let constr_lid = Located.map lident cnstr in
         branch_sum
@@ -748,8 +748,6 @@ module Str_generate_sexp_of = struct
               Conversion.to_expression
                 ~loc
                 (Conversion.of_lambda [ converter; assert_false ])]]
-      | { pext_name = cnstr; pext_kind = Pext_decl (_, extension_constructor_kind, None); _ } ->
-        Location.raise_errorf ~loc "sexp_of_exn/: Explicit binders for type variables aren't supported"
       | { pext_kind = Pext_decl (_, _, Some _); _ } ->
         Location.raise_errorf ~loc "sexp_of_exn/:"
       | { pext_kind = Pext_rebind _; _ } ->

--- a/expander/expand_sexp_of.ml
+++ b/expander/expand_sexp_of.ml
@@ -727,7 +727,7 @@ module Str_generate_sexp_of = struct
     let loc = ec.ptyexn_loc in
     let expr =
       match ec.ptyexn_constructor with
-      | { pext_name = cnstr; pext_kind = Pext_decl (extension_constructor_kind, None); _ }
+      | { pext_name = cnstr; pext_kind = Pext_decl ([], extension_constructor_kind, None); _ }
         ->
         let constr_lid = Located.map lident cnstr in
         branch_sum
@@ -748,7 +748,9 @@ module Str_generate_sexp_of = struct
               Conversion.to_expression
                 ~loc
                 (Conversion.of_lambda [ converter; assert_false ])]]
-      | { pext_kind = Pext_decl (_, Some _); _ } ->
+      | { pext_name = cnstr; pext_kind = Pext_decl (_, extension_constructor_kind, None); _ } ->
+        Location.raise_errorf ~loc "sexp_of_exn/: Explicit binders for type variables aren't supported"
+      | { pext_kind = Pext_decl (_, _, Some _); _ } ->
         Location.raise_errorf ~loc "sexp_of_exn/:"
       | { pext_kind = Pext_rebind _; _ } ->
         Location.raise_errorf ~loc "sexp_of_exn/rebind"

--- a/ppx_sexp_conv.opam
+++ b/ppx_sexp_conv.opam
@@ -15,7 +15,7 @@ depends: [
   "base"     {>= "v0.15" & < "v0.16"}
   "sexplib0" {>= "v0.15" & < "v0.16"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.23.0"}
+  "ppxlib"   {>= "0.26.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "


### PR DESCRIPTION
This is a patch PR to make the PPX compatible with ppxlib.0.26.0 which has bumped the AST to 4.14/5.00.